### PR TITLE
typedef member-variable-declaration rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -79,7 +79,8 @@
       true,
       "call-signature",
       "property-declaration",
-      "parameter"
+      "parameter",
+      "member-variable-declaration"
     ],
     "typedef-whitespace": [
       true,


### PR DESCRIPTION
Kolejna zmiana w typedef!
Do obecnego zestawu sprawdzania typu, dołączyło sprawdzanie zmiennych zdefiniowanych w klasie.
Spowoduje, to mniejsze zastanawianie się nad typem oraz mniej błędów na runtime :)
Więcej informacji o typedef:
[typedef](https://palantir.github.io/tslint/rules/typedef/)